### PR TITLE
fix: stable-release 워크플로우 push 이벤트로 변경

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,8 +1,7 @@
 name: Stable Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
@@ -14,7 +13,6 @@ permissions:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## 🐛 문제
- stable-release.yml이 pull_request 이벤트로 트리거되어 semantic-release가 배포하지 않음
- `This run was triggered by a pull request and therefore a new version won't be published` 오류 발생

## 🔧 해결
- 워크플로우 트리거를 `push` 이벤트로 변경
- main 브랜치에 push될 때 자동으로 semantic-release 실행
- PR 병합 조건 제거

## 📋 변경사항
```yaml
# Before
on:
  pull_request:
    types: [closed]
    branches:
      - main

# After  
on:
  push:
    branches:
      - main
```

## ✅ 예상 결과
- PR 병합 후 main 브랜치로 push되면 자동으로 정식 버전 배포
- npm에 latest 태그로 패키지 발행
- GitHub Release 생성

## 🧪 테스트
- [x] 워크플로우 문법 검증
- [x] semantic-release 설정 확인