### PR TITLE
fix: stable-release npm 인증 문제 해결

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -50,4 +50,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 🐛 문제
stable-release 워크플로우에서 npm 인증 실패
- 오류: `401 Unauthorized - Invalid npm token`
- 원인: `NODE_AUTH_TOKEN` 환경 변수 누락

## 🔧 해결
- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` 추가
- beta-release.yml과 동일한 인증 방식 적용

## 📋 변경사항
```yaml
- name: Run semantic-release
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}  # ✅ 추가
  run: npx semantic-release
```

## 🔍 분석
- `actions/setup-node`는 `NODE_AUTH_TOKEN`을 사용하여 .npmrc 생성
- semantic-release는 이 인증 정보를 사용하여 npm에 패키지 발행
- beta-release.yml은 이미 이 방식을 사용하여 정상 작동중

## ✅ 예상 결과
- PR 병합 후 main 브랜치에서 정식 버전 자동 배포
- npm에 latest 태그로 패키지 발행
- GitHub Release 생성